### PR TITLE
Add -exitonhalt option to aid automation

### DIFF
--- a/Base/CPU.cpp
+++ b/Base/CPU.cpp
@@ -54,6 +54,7 @@ sam_cpu cpu;
 
 
 bool g_fBreak, g_fPaused;
+bool g_fQuit;
 int g_nTurbo;
 
 constexpr auto max_boot_frames{ 200 };
@@ -150,7 +151,7 @@ void ExecuteChunk()
 
 void Run()
 {
-    while (UI::CheckEvents())
+    while (!g_fQuit && UI::CheckEvents())
     {
         if (g_fPaused)
             continue;

--- a/Base/CPU.h
+++ b/Base/CPU.h
@@ -65,6 +65,7 @@ extern uint8_t last_in_val, last_out_val;
 }
 
 extern bool g_fBreak, g_fPaused;
+extern bool g_fQuit;
 extern int g_nTurbo;
 
 #ifdef _DEBUG
@@ -156,6 +157,22 @@ struct sam_cpu : public z80::z80_cpu<sam_cpu>
             return;
 
         base::on_rst(nn);
+    }
+
+    void on_halt()
+    {
+        // Batch-mode: quit cleanly when the Z80 executes HALT with
+        // interrupts disabled. A HALT with IFF1=0 can never be woken
+        // by a maskable interrupt, so it is an unambiguous "we are done"
+        // signal from the Z80 program. Without -exitonhalt, behaviour is
+        // unchanged: the Z80 enters its normal HALT state and waits for
+        // the next interrupt.
+        if (GetOption(exitonhalt) && !base::on_get_iff1())
+        {
+            g_fQuit = true;
+            g_fBreak = true;
+        }
+        base::on_halt();
     }
 
     z80::fast_u8 on_get_int_vector()

--- a/Base/Options.cpp
+++ b/Base/Options.cpp
@@ -142,6 +142,7 @@ static bool SetNamedValue(const std::string& option_name, const std::string& str
     else if (name == "breakonexec") SetValue(g_config.breakonexec, str);
     else if (name == "fkeys") SetValue(g_config.fkeys, str);
     else if (name == "rasterdebug") SetValue(g_config.rasterdebug, str);
+    else if (name == "exitonhalt") SetValue(g_config.exitonhalt, str);
     else
     {
         return false;

--- a/Base/Options.h
+++ b/Base/Options.h
@@ -127,6 +127,8 @@ struct Config
     bool breakonexec = false;           // Break on code auto-execute?
     bool rasterdebug = true;            // Raster-accurate debugger display
 
+    bool exitonhalt = false;            // Quit when Z80 executes DI;HALT? (batch mode; not saved, same as autoboot)
+
     std::string fkeys =                 // Function key bindings
         "F1=InsertDisk1,SF1=EjectDisk1,AF1=NewDisk1,CF1=SaveDisk1,"
         "F2=InsertDisk2,SF2=EjectDisk2,AF2=NewDisk2,CF2=SaveDisk2,"


### PR DESCRIPTION
Hey Simon! Long time no see! Hope all is well.

This patch would be useful for me where I am using Sim Coupé to test some SAM software I am writing, as I could not find an idiomatic way to gracefully terminate Sim Coupé when tests complete. Let me know what you think! I chose to make `-exitonhalt` a command line option _only_ rather than persisting to config, basically in line with what you have for `autoboot`. Happy to change that if you prefer it to live in config too. My reasoning was that typically this is a flag you would set in automation, so being explicit is good and unlikely you would want to persist the setting across invocations. But I don't mind either way.

Thanks!