### PR TITLE
Support paste (Command-V) on macOS

### DIFF
--- a/Base/Actions.cpp
+++ b/Base/Actions.cpp
@@ -29,6 +29,7 @@
 #include "GUI.h"
 #include "GUIDlg.h"
 #include "Input.h"
+#include "Keyin.h"
 #include "Options.h"
 #include "Parallel.h"
 #include "Sound.h"
@@ -373,6 +374,10 @@ bool Do(Action action, bool pressed/*=true*/)
         case Action::SpeedNormal:
             SetOption(speed, 100);
             Frame::SetStatus("100% Speed");
+            break;
+
+        case Action::Paste:
+            Keyin::String(OSD::GetClipboardText());
             break;
 
             // Not processed

--- a/SDL/OSX/SDLMain.m
+++ b/SDL/OSX/SDLMain.m
@@ -7,7 +7,7 @@
 
 #import <SDL2/SDL.h>
 #import "SDLMain.h"
-#include "../UI.h"      // For UE_* user event definitions
+#include "../UI.h"      // UE_* user event codes and sim_can_paste bridge
 
 extern int SimCoupe_main (int argc_, char* argv_[]);
 
@@ -118,6 +118,17 @@ static void setupApplicationMenus ()
     [item setKeyEquivalentModifierMask:(NSEventModifierFlagShift|NSEventModifierFlagCommand)];
     
     item = [[NSMenuItem alloc] initWithTitle:@"File" action:nil keyEquivalent:@""];
+    [item setSubmenu:menu];
+    [[NSApp mainMenu] addItem:item];
+    [item release];
+    [menu release];
+
+    /* Create the Edit menu */
+    menu = [[NSMenu alloc] initWithTitle:@"Edit"];
+
+    [menu addItemWithTitle:@"Paste" action:@selector(editPaste:) keyEquivalent:@"v"];
+
+    item = [[NSMenuItem alloc] initWithTitle:@"Edit" action:nil keyEquivalent:@""];
     [item setSubmenu:menu];
     [[NSApp mainMenu] addItem:item];
     [item release];
@@ -271,6 +282,22 @@ static void sendUserEvent (int event)
 }
 
 
+// NSMenuValidation: grey out Paste when SAM cannot accept keys or
+// the clipboard has no text.
+- (BOOL)validateMenuItem:(NSMenuItem *)item
+{
+    if ([item action] == @selector(editPaste:))
+    {
+        if (!sim_can_paste())
+            return NO;
+        NSPasteboard *pb = [NSPasteboard generalPasteboard];
+        if (![pb availableTypeFromArray:@[NSPasteboardTypeString]])
+            return NO;
+        return YES;
+    }
+    return YES;
+}
+
 - (IBAction)appPreferences:(id)sender { sendUserEvent(UE_OPTIONS); }
 - (IBAction)systemPause:(id)sender { sendUserEvent(UE_PAUSE); }
 - (IBAction)systemNMI:(id)sender { sendUserEvent(UE_NMIBUTTON); }
@@ -281,6 +308,7 @@ static void sendUserEvent (int event)
 - (IBAction)viewRatio54:(id)sender { sendUserEvent(UE_TOGGLETV); }
 - (IBAction)fileImportData:(id)sender { sendUserEvent(UE_IMPORTDATA); }
 - (IBAction)fileExportData:(id)sender { sendUserEvent(UE_EXPORTDATA); }
+- (IBAction)editPaste:(id)sender { sendUserEvent(UE_PASTE); }
 
 
 - (IBAction)openDocument:(id)sender

--- a/SDL/UI.cpp
+++ b/SDL/UI.cpp
@@ -30,6 +30,7 @@
 #include "Frame.h"
 #include "GUI.h"
 #include "Input.h"
+#include "Keyin.h"
 #include "Options.h"
 #include "Sound.h"
 #include "SDL20.h"
@@ -178,6 +179,7 @@ bool UI::CheckEvents()
                 case UE_RECORDGIFLOOP:      Actions::Do(Action::RecordGifLoop);   break;
                 case UE_RECORDWAV:          Actions::Do(Action::RecordWav);       break;
                 case UE_RECORDWAVSEGMENT:   Actions::Do(Action::RecordWavSegment); break;
+                case UE_PASTE:              Actions::Do(Action::Paste);           break;
 
                 default:
                     TRACE("Unhandled user event ({})\n", event.type);
@@ -240,4 +242,9 @@ bool UI::DoAction(Action action, bool pressed)
 
     // Action processed
     return true;
+}
+
+extern "C" bool sim_can_paste(void)
+{
+    return Keyin::CanType();
 }

--- a/SDL/UI.h
+++ b/SDL/UI.h
@@ -71,3 +71,14 @@ extern bool g_fActive;
 #define UE_RECORDAVIHALF        (UE_BASE+24)
 #define UE_RECORDAVISTOP        (UE_BASE+25)
 #define UE_QUEUEFILE            (UE_BASE+26)
+#define UE_PASTE                (UE_BASE+27)
+
+// C-callable bridge: returns true if the SAM can currently accept paste.
+// Called from validateMenuItem: in SDL/OSX/SDLMain.m.
+#ifdef __cplusplus
+extern "C" {
+#endif
+bool sim_can_paste(void);
+#ifdef __cplusplus
+}
+#endif

--- a/Win32/UI.cpp
+++ b/Win32/UI.cpp
@@ -960,13 +960,6 @@ bool UI::DoAction(Action action, bool pressed)
             return false;
         }
 
-        case Action::Paste:
-        {
-            auto text = OSD::GetClipboardText();
-            Keyin::String(text);
-            break;
-        }
-
         // Not processed
         default:
             return false;


### PR DESCRIPTION
Hey Simon!
 
As you liked the last feature, here is another one. On Windows I saw you could paste from the clipboard, but not under SDL. This patch adds paste support to the SDL build, with a menu on macOS (Edit -> Paste (Cmd+V)). This mirrors the Windows menu option Tools -> Paste Clipboard. On Linux you'd still need to wire it up via the fkeys config (no menu added there). I'm happy to add a Linux UI hook in a follow-up if you like.

One incidental refactor: I moved the Action::Paste handler from Win32/UI.cpp into Base/Actions.cpp so it could be shared.

Let me know what you think! I had some help from Claude on this one, I have to level with you. Luckily though it has quite a small footprint, as I think you had done most of the hard work already!

I've tested quite a bit on macOS, and it works well for me. I'm able to paste entire SAM BASIC programs into the editor etc.

Thanks,
Pete